### PR TITLE
feat(frontend): add basic encryption UI

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -63,3 +63,49 @@ body {
 ol {
   text-align: left;
 }
+
+/* Encryption section */
+.drop-zone {
+  border: 2px dashed #666;
+  padding: 20px;
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+
+.drop-zone.hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.passwords {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.password-field {
+  padding: 6px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #111;
+  color: #fff;
+}
+
+#addPassword, #encryptBtn {
+  margin: 5px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: #444;
+  color: #fff;
+}
+
+.terminal {
+  background: #000;
+  color: #0f0;
+  padding: 10px;
+  height: 150px;
+  overflow-y: auto;
+  text-align: left;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,18 @@
         <li data-i18n="step5">To restore, scan all QR codes and decrypt using the same password</li>
       </ol>
     </div>
+    <section id="encryptSection" class="card">
+      <h2 data-i18n="encryptTitle">Encrypt File</h2>
+      <div id="dropZone" class="drop-zone" data-i18n="dropText">Drop file here or click to select</div>
+      <input type="file" id="fileInput" class="hidden" />
+      <div class="passwords">
+        <input type="password" class="password-field" placeholder="Password #1">
+        <input type="password" class="password-field" placeholder="Password #2">
+      </div>
+      <button id="addPassword" data-i18n="addPass">Add password</button>
+      <button id="encryptBtn" data-i18n="encryptBtn">Encrypt</button>
+      <pre id="terminal" class="terminal"></pre>
+    </section>
   </main>
   <script src="index.js"></script>
 </body>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -7,7 +7,11 @@ const translations = {
     step2: "Derive a key via scrypt and encrypt with AES-256-GCM",
     step3: "Split the ciphertext into QR-sized chunks",
     step4: "Embed each chunk directly into a QR image (base64 payload)",
-    step5: "To restore, scan all QR codes and decrypt using the same password"
+    step5: "To restore, scan all QR codes and decrypt using the same password",
+    encryptTitle: "Encrypt File",
+    dropText: "Drop file here or click to select",
+    addPass: "Add password",
+    encryptBtn: "Encrypt"
   },
   ru: {
     title: "GitZipQR",
@@ -17,7 +21,11 @@ const translations = {
     step2: "Получите ключ через scrypt и зашифруйте AES-256-GCM",
     step3: "Разделите шифртекст на части размером с QR-код",
     step4: "Встроите каждую часть непосредственно в изображение QR (base64)",
-    step5: "Для восстановления отсканируйте все QR-коды и расшифруйте тем же паролем"
+    step5: "Для восстановления отсканируйте все QR-коды и расшифруйте тем же паролем",
+    encryptTitle: "Зашифровать файл",
+    dropText: "Перетащите файл сюда или нажмите для выбора",
+    addPass: "Добавить пароль",
+    encryptBtn: "Зашифровать"
   }
 };
 
@@ -49,3 +57,79 @@ langMenu.querySelectorAll('button').forEach(btn => {
 
 // set default language
 applyLang('en');
+
+/* ---------------- Encryption UI ---------------- */
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
+const addPassword = document.getElementById('addPassword');
+const encryptBtn = document.getElementById('encryptBtn');
+const terminal = document.getElementById('terminal');
+const passwordsDiv = document.querySelector('.passwords');
+let selectedFile = null;
+
+function log(msg) {
+  terminal.textContent += msg + '\n';
+  terminal.scrollTop = terminal.scrollHeight;
+}
+
+dropZone.addEventListener('click', () => fileInput.click());
+
+dropZone.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  dropZone.classList.add('hover');
+});
+
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('hover'));
+
+dropZone.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropZone.classList.remove('hover');
+  const f = e.dataTransfer.files[0];
+  if (f) {
+    selectedFile = f;
+    log('File selected: ' + f.name);
+  }
+});
+
+fileInput.addEventListener('change', (e) => {
+  const f = e.target.files[0];
+  if (f) {
+    selectedFile = f;
+    log('File selected: ' + f.name);
+  }
+});
+
+addPassword.addEventListener('click', () => {
+  const count = passwordsDiv.querySelectorAll('input').length + 1;
+  const inp = document.createElement('input');
+  inp.type = 'password';
+  inp.className = 'password-field';
+  inp.placeholder = `Password #${count}`;
+  passwordsDiv.appendChild(inp);
+});
+
+async function encryptFile() {
+  if (!selectedFile) { log('No file selected'); return; }
+  const pwEls = passwordsDiv.querySelectorAll('input');
+  const pw = Array.from(pwEls).map(i => i.value).filter(Boolean).join('\u0000');
+  if (!pw) { log('No passwords provided'); return; }
+  log('Encrypting ' + selectedFile.name + ' ...');
+  try {
+    const data = new Uint8Array(await selectedFile.arrayBuffer());
+    const enc = new TextEncoder();
+    const pwKey = await crypto.subtle.importKey('raw', enc.encode(pw), 'PBKDF2', false, ['deriveKey']);
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await crypto.subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' }, pwKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+    const out = new Uint8Array(salt.length + iv.length + cipher.byteLength);
+    out.set(salt, 0);
+    out.set(iv, salt.length);
+    out.set(new Uint8Array(cipher), salt.length + iv.length);
+    log('Encryption complete. Bytes: ' + out.length);
+  } catch (e) {
+    log('Error: ' + e.message);
+  }
+}
+
+encryptBtn.addEventListener('click', encryptFile);


### PR DESCRIPTION
## Summary
- add file encryption section with drag-and-drop and multi-password support
- log encryption progress to on-page terminal
- local AES-GCM encryption in browser via WebCrypto

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaf3a5fce8832ab2e0055d032d73df