### PR TITLE
fix(frontend): dynamically load jsQR for decryption

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="index.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode/1.5.1/qrcode.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jsqr/1.4.0/jsQR.min.js"></script>
 </head>
 <body>
   <header class="top-bar">


### PR DESCRIPTION
## Summary
- dynamically load jsQR on demand to avoid missing decoder during decryption
- drop static jsQR CDN script tag

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac2272f5dc832a810fb39a58554c8c